### PR TITLE
Fix for #9: docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update -y
 RUN apt-get install python3 python3-pip unzip wget -y
 COPY . /app
 WORKDIR app/
+RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
 RUN pip3 install jupyterlab notebook
 RUN pip3 install git+https://github.com/mihaidusmanu/pycolmap


### PR DESCRIPTION
This fixes the docker build error: ModuleNotFoundError: No module named 'skbuild'

After this change, as suggested by @Skydes, the docker built successfully.