### PR TITLE
cv2 resize hangs

### DIFF
--- a/hloc/extract_features.py
+++ b/hloc/extract_features.py
@@ -13,6 +13,8 @@ from . import extractors
 from .utils.base_model import dynamic_load
 from .utils.tools import map_tensor
 
+# https://stackoverflow.com/questions/54013846/pytorch-dataloader-stucked-if-using-opencv-resize-method
+cv2.setNumThreads(0)
 
 '''
 A set of standard configurations that can be directly selected from the command


### PR DESCRIPTION
With large images, cv2.resize() is called.
https://github.com/cvg/Hierarchical-Localization/blob/99676f7a98db0b3e69dc42122de2f972f966f210/hloc/extract_features.py#L100

However this hangs the pytorch dataloader due to a threading issue (see https://stackoverflow.com/questions/54013846/pytorch-dataloader-stucked-if-using-opencv-resize-method).