### PR TITLE
add flags to provide GPU support to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We also provide a Docker image that includes COLMAP and other dependencies:
 
 ```
 docker build -t hloc:latest .
-docker run -it -p 8888:8888 hloc:latest
+docker run -it --rm -p 8888:8888 hloc:latest # to run with GPU support, add this option: `--runtime=nvidia`
 jupyter notebook --ip 0.0.0.0 --port 8888 --no-browser --allow-root
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We also provide a Docker image that includes COLMAP and other dependencies:
 
 ```
 docker build -t hloc:latest .
-docker run -it --rm -p 8888:8888 hloc:latest # to run with GPU support, add this option: `--runtime=nvidia`
+docker run -it --rm -p 8888:8888 hloc:latest  # for GPU support, add `--runtime=nvidia`
 jupyter notebook --ip 0.0.0.0 --port 8888 --no-browser --allow-root
 ```
 


### PR DESCRIPTION
To run on a GPU, the container must be started with access to the nvidia runtime. (I believe this was the problem in issue #23)