### PR TITLE
Added NetVLAD implementation.

### DIFF
--- a/hloc/extract_features.py
+++ b/hloc/extract_features.py
@@ -83,6 +83,15 @@ confs = {
             'resize_max': None,
         },
     },
+    'netvlad': {
+        'output': 'global-feats-netvlad',
+        'model': {
+            'name': 'netvlad',
+        },
+        'preprocessing': {
+            'resize_max': None,
+        },
+    },
 }
 
 

--- a/hloc/extractors/netvlad.py
+++ b/hloc/extractors/netvlad.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+import subprocess
+import logging
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchvision.models as models
+from scipy.io import loadmat
+
+from ..utils.base_model import BaseModel
+
+
+netvlad_path = Path(__file__).parent / '../../third_party/netvlad'
+
+
+EPS = 1e-6
+
+
+class NetVLADLayer(nn.Module):
+    def __init__(self, input_dim=512, K=64, score_bias=False, intranorm=True):
+        super().__init__()
+        self.score_proj = nn.Conv1d(input_dim, K, kernel_size=1, bias=score_bias)
+        centers = nn.parameter.Parameter(torch.empty([input_dim, K]))
+        nn.init.xavier_uniform_(centers)
+        self.register_parameter('centers', centers)
+        self.intranorm = intranorm
+        self.output_dim = input_dim * K
+    
+    def forward(self, x):
+        b = x.size(0)
+        scores = self.score_proj(x)
+        scores = F.softmax(scores, dim=1)
+        diff = (x.unsqueeze(2) - self.centers.unsqueeze(0).unsqueeze(-1))
+        desc = (scores.unsqueeze(1) * diff).sum(dim=-1)
+        if self.intranorm:
+            # From the official MATLAB implementation.
+            desc = F.normalize(desc, dim=1)
+        desc = desc.view(b, -1)
+        desc = F.normalize(desc, dim=1)
+        return desc
+
+
+class NetVLAD(BaseModel):
+    default_conf = {
+        'model_name': 'VGG16-NetVLAD-Pitts30K',
+        'checkpoint_dir': netvlad_path,
+        'whiten': True
+    }
+    required_inputs = ['image']
+    
+    # Models exported using https://github.com/uzh-rpg/netvlad_tf_open/blob/master/matlab/net_class2struct.m.
+    dir_models = {
+        'VGG16-NetVLAD-Pitts30K': 'https://dsmn.ml/files/netvlad/Pitts30K_struct.mat',
+        'VGG16-NetVLAD-TokyoTM': 'https://dsmn.ml/files/netvlad/TokyoTM_struct.mat'
+    }
+
+    def _init(self, conf):
+        assert conf['model_name'] in self.dir_models.keys()
+
+        # Download the checkpoint.
+        checkpoint = conf['checkpoint_dir'] / str(conf['model_name'] + '.mat')
+        if not checkpoint.exists():
+            checkpoint.parent.mkdir(exist_ok=True)
+            link = self.dir_models[conf['model_name']]
+            cmd = ['wget', link, '-O', str(checkpoint)]
+            logging.info(f'Downloading theNetVLAD model with `{cmd}`.')
+            ret = subprocess.call(cmd)
+            if ret != 0:
+                logging.warning(f'Cannot download the NetVLAD model with `{cmd}`.')
+                exit(ret)
+
+        # Create the network.
+        backbone = list(models.vgg16().children())[0]  # Remove classification head.
+        self.backbone = nn.Sequential(
+            *list(backbone.children())[: -2]  # Remove last ReLU + MaxPool2d.
+        )
+
+        self.netvlad = NetVLADLayer()
+
+        self.whiten = nn.Linear(self.netvlad.output_dim, 4096) if conf['whiten'] else nn.Identity()
+
+        # Parse MATLAB weights - based on https://github.com/uzh-rpg/netvlad_tf_open.
+        mat = loadmat(checkpoint, struct_as_record=False, squeeze_me=True)
+
+        ## CNN weights.
+        for layer, mat_layer in zip(self.backbone.children(), mat['net'].layers):
+            if isinstance(layer, nn.Conv2d):
+                w = mat_layer.weights[0]  # Shape: S x S x IN x OUT
+                b = mat_layer.weights[1]  # Shape: OUT
+                # Prepare for PyTorch - make sure it is float32 and has right shape.
+                w = torch.tensor(w).float().permute([3, 2, 0, 1])  # Shape: OUT x IN x S x S
+                b = torch.tensor(b).float()  # Shape: OUT
+                # Update layer weights.
+                layer.weight = nn.Parameter(w)
+                layer.bias = nn.Parameter(b)
+
+        ## NetVLAD weights.
+        score_w = mat['net'].layers[30].weights[0]  # D x K
+        center_w = -mat['net'].layers[30].weights[1]  # D x K, centers are stored as opposite in official MATLAB code.
+        # Prepare for PyTorch - make sure it is float32 and has right shape.
+        score_w = torch.tensor(score_w).float().permute([1, 0]).unsqueeze(-1)  # Shape: K x D x 1
+        center_w = torch.tensor(center_w).float()  # Shape: D x K
+        # Update layer weights.
+        self.netvlad.score_proj.weight = nn.Parameter(score_w)
+        self.netvlad.centers = nn.Parameter(center_w)
+    
+        ## Whitening weights.
+        if conf['whiten']:
+            w = mat['net'].layers[33].weights[0]  # Shape: 1 x 1 x IN x OUT
+            b = mat['net'].layers[33].weights[1]  # Shape: OUT
+            # Prepare for PyTorch - make sure it is float32 and has right shape.
+            w = torch.tensor(w).float().squeeze().permute([1, 0])  # Shape: OUT x IN
+            b = torch.tensor(b.squeeze()).float()  # Shape: OUT
+            # Update layer weights.
+            self.whiten.weight = nn.Parameter(w)
+            self.whiten.bias = nn.Parameter(b)
+        
+        ## Preprocessing parameters.
+        self.preprocess = {
+            'mean': mat['net'].meta.normalization.averageImage[0, 0],
+            'std': np.array([1, 1, 1], dtype=np.float32)
+        }
+
+    def _forward(self, data):
+        image = data['image']
+        assert image.shape[1] == 3
+        assert image.min() >= -EPS and image.max() <= 1 + EPS
+        image = torch.clamp(image * 255, 0.0, 255.0)  # Input should be 0-255.
+        mean = self.preprocess['mean']
+        std = self.preprocess['std']
+        image = image - image.new_tensor(mean).view(1, -1, 1, 1)
+        image = image / image.new_tensor(std).view(1, -1, 1, 1)
+
+        # Feature extraction.
+        descriptors = self.backbone(image)
+        b, c, _, _ = descriptors.size()
+        descriptors = descriptors.view(b, c, -1)
+
+        # NetVLAD layer.
+        descriptors = F.normalize(descriptors, dim=1)  # Pre-normalization.
+        desc = self.netvlad(descriptors)
+
+        # Whiten if needed.
+        if hasattr(self, 'whiten'):
+            desc = self.whiten(desc)
+            desc = F.normalize(desc, dim=1)  # Final L2 normalization.
+
+        return {
+            'global_descriptor': desc
+        }

--- a/hloc/extractors/netvlad.py
+++ b/hloc/extractors/netvlad.py
@@ -78,7 +78,8 @@ class NetVLAD(BaseModel):
 
         self.netvlad = NetVLADLayer()
 
-        self.whiten = nn.Linear(self.netvlad.output_dim, 4096) if conf['whiten'] else nn.Identity()
+        if conf['whiten']:
+            self.whiten = nn.Linear(self.netvlad.output_dim, 4096)
 
         # Parse MATLAB weights - based on https://github.com/uzh-rpg/netvlad_tf_open.
         mat = loadmat(checkpoint, struct_as_record=False, squeeze_me=True)


### PR DESCRIPTION
NetVLAD implementation using original weights and architecture, based on:
- https://www.di.ens.fr/willow/research/netvlad/
- https://github.com/uzh-rpg/netvlad_tf_open

On a few demo images, final descriptors are slightly different w.r.t. original MATLAB ones (~5e-3 distance). This is the same behaviour as the TF re-implementation (see https://github.com/uzh-rpg/netvlad_tf_open/blob/master/tests/test_nets.py#L47). However, results seem consistent with TF re-implementation (~1e-5 distance).
