### PR TITLE
Added SIFT features using PyCOLMAP.

### DIFF
--- a/hloc/extract_features.py
+++ b/hloc/extract_features.py
@@ -74,6 +74,16 @@ confs = {
             'resize_max': 1600,
         },
     },
+    'sift': {
+        'output': 'feats-sift',
+        'model': {
+            'name': 'sift'
+        },
+        'preprocessing': {
+            'grayscale': True,
+            'resize_max': 1600,
+        },
+    },
     'dir': {
         'output': 'global-feats-dir',
         'model': {

--- a/hloc/extractors/sift.py
+++ b/hloc/extractors/sift.py
@@ -44,6 +44,8 @@ class SIFT(BaseModel):
 
     def _forward(self, data):
         image = data['image']
+        assert image.shape[1] == 1
+        assert image.min() >= -EPS and image.max() <= 1 + EPS
 
         keypoints, scores, descriptors = self.extract(image[0, 0].cpu().numpy())
         keypoints = keypoints[:, : 2]  # Keep only x, y.

--- a/hloc/extractors/sift.py
+++ b/hloc/extractors/sift.py
@@ -1,0 +1,65 @@
+import copy
+import numpy as np
+import torch
+
+from ..utils.base_model import BaseModel
+
+import pycolmap
+
+
+EPS = 1e-6
+
+
+def sift_to_rootsift(descs):
+    l1_norm_descs = descs / (np.linalg.norm(descs, ord=1, axis=-1)[:, np.newaxis] + EPS)
+    sqrt_l1_norm_descs = np.sqrt(l1_norm_descs)
+    root_descs = sqrt_l1_norm_descs / (np.linalg.norm(sqrt_l1_norm_descs, axis=-1)[:, np.newaxis] + EPS)
+    return root_descs
+
+
+class SIFT(BaseModel):
+    default_conf = {
+        'num_octaves': 4,
+        'octave_resolution': 3,
+        'first_octave': 0,
+        'edge_thresh': 10,
+        'peak_thresh': 0.01,
+        'upright': False,
+        'root': True,
+        'max_keypoints': -1
+    }
+    required_inputs = ['image']
+
+    def _init(self, conf):
+        self.root = conf['root']
+        self.max_keypoints = conf['max_keypoints']
+
+        vlfeat_conf = copy.deepcopy(conf)
+        vlfeat_conf.pop('name', None)
+        vlfeat_conf.pop('root', None)
+        vlfeat_conf.pop('max_keypoints', None)
+        self.extract = lambda image: pycolmap.extract_sift(
+            image, **vlfeat_conf
+        )
+
+    def _forward(self, data):
+        image = data['image']
+
+        keypoints, scores, descriptors = self.extract(image[0, 0].cpu().numpy())
+        keypoints = keypoints[:, : 2]  # Keep only x, y.
+
+        if self.root:
+            descriptors = sift_to_rootsift(descriptors)
+        
+        if self.max_keypoints != -1:
+            # It is unclear whether scores from PyCOLMAP are 100% correct - follow https://github.com/mihaidusmanu/pycolmap/issues/8.
+            indices = np.argsort(scores)[:: -1][: self.max_keypoints]
+            keypoints = keypoints[indices, :]
+            scores = scores[indices]
+            descriptors = descriptors[indices, :]
+
+        return {
+            'keypoints': torch.from_numpy(keypoints)[None],
+            'scores': torch.from_numpy(scores)[None],
+            'descriptors': torch.from_numpy(descriptors.T)[None],
+        }

--- a/hloc/match_features.py
+++ b/hloc/match_features.py
@@ -33,6 +33,14 @@ confs = {
             'mutual_check': True,
             'distance_threshold': 0.7,
         },
+    },
+    'NN-ratio': {
+        'output': 'matches-NN-mutual-ratio.8',
+        'model': {
+            'name': 'nearest_neighbor',
+            'mutual_check': True,
+            'ratio_threshold': 0.8,
+        }
     }
 }
 


### PR DESCRIPTION
I implemented a simple interface for VLFeat SIFT from PyCOLMAP.

There might some issue with top keypoints selection - I opened an issue on the PyCOLMAP repository to follow up https://github.com/mihaidusmanu/pycolmap/issues/8.

I get the following results on South-Building without image downsampling and `max_keypoints=10000` (to avoid GPU memory issues during matching):
```
{
  'mean_reproj_error': 0.450604,
  'mean_track_length': 7.001359,
  'num_input_images': 128,
  'num_observations': 535786,
  'num_observations_per_image': 4185.828125,
  'num_reg_images': 128,
  'num_sparse_points': 76526
}
 ```
which seems reasonable 😄.