### PR TITLE
…

### DIFF
--- a/hloc/extract_features.py
+++ b/hloc/extract_features.py
@@ -148,6 +148,8 @@ class ImageDataset(torch.utils.data.Dataset):
             image = image.transpose((2, 0, 1))  # HxWxC to CxHxW
         image = image / 255.
 
+        if isinstance(path, str):
+            path = Path(path)
         data = {
             'name': path.as_posix(),
             'image': image,

--- a/hloc/localize_sfm.py
+++ b/hloc/localize_sfm.py
@@ -120,6 +120,9 @@ def main(reference_sfm, queries, retrieval, features, matches, results,
     }
     logging.info('Starting localization...')
     for qname, qinfo in tqdm(queries):
+        if qname not in retrieval_dict:
+            logging.warning(f'No images retrieved for query image {qname}. Skipping...')
+            continue
         db_names = retrieval_dict[qname]
         db_ids = []
         for n in db_names:


### PR DESCRIPTION
When using image lists for feature extraction, 'path' in getitem is no instance of Path (it is a str) and it will crash when trying to call path.as_posix().

I also added a warning if there are no db images retrieved (for some reason) for a query image. Such queries will be skipped.