### PR TITLE
fixed pycolmap github repo issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tqdm
 matplotlib
 scipy
 h5py
-git+https://github.com/mihaidusmanu/pycolmap
+git+https://github.com/mihaidusmanu/pycolmap@fe5b30345d5de31f9376675c68f19348149426b0


### PR DESCRIPTION
```pip3 install git+https://github.com/mihaidusmanu/pycolmap``` have some compiler error while installing. 
This is due to dependency on new PR merged in ```colmap/colmap```.  Checking out to a different commit works.
I have changed ```requirements.txt``` file pointing to ```pycolmap``` project commit ```fe5b30345d5de31f9376675c68f19348149426b0```  which has no installation issue. 

ref - https://issueexplorer.com/issue/mihaidusmanu/pycolmap/15