### PR TITLE
NN fix when no features detected in image.

### DIFF
--- a/hloc/matchers/nearest_neighbor.py
+++ b/hloc/matchers/nearest_neighbor.py
@@ -4,11 +4,6 @@ from ..utils.base_model import BaseModel
 
 
 def find_nn(sim, ratio_thresh, distance_thresh):
-    *dims, n = sim.shape
-    if n == 0:
-        return torch.full(dims, -1, device=sim.device), sim.new_zeros(dims)
-    elif n == 1:
-        ratio_thresh = False
     sim_nn, ind_nn = sim.topk(2 if ratio_thresh else 1, dim=-1, largest=True)
     dist_nn = 2 * (1 - sim_nn)
     mask = torch.ones(ind_nn.shape[:-1], dtype=torch.bool, device=sim.device)
@@ -22,8 +17,6 @@ def find_nn(sim, ratio_thresh, distance_thresh):
 
 
 def mutual_check(m0, m1):
-    if m1.shape[-1] == 0:
-        return m0
     inds0 = torch.arange(m0.shape[-1], device=m0.device)
     loop = torch.gather(m1, -1, torch.where(m0 > -1, m0, m0.new_tensor(0)))
     ok = (m0 > -1) & (inds0 == loop)
@@ -43,13 +36,23 @@ class NearestNeighbor(BaseModel):
         pass
 
     def _forward(self, data):
+        if data['descriptors0'].size(-1) == 0 or data['descriptors1'].size(-1) == 0:
+            b = data['descriptors0'].size(0)
+            device = data['descriptors0'].device
+            return {
+                'matches0': torch.zeros([b, 0]).to(device),
+                'matching_scores0': torch.zeros([b, 0]).to(device)
+            }
+        ratio_threshold = self.conf['ratio_threshold']
+        if data['descriptors0'].size(-1) == 1 or data['descriptors1'].size(-1) == 1:
+            ratio_threshold = None
         sim = torch.einsum(
             'bdn,bdm->bnm', data['descriptors0'], data['descriptors1'])
         matches0, scores0 = find_nn(
-            sim, self.conf['ratio_threshold'], self.conf['distance_threshold'])
+            sim, ratio_threshold, self.conf['distance_threshold'])
         if self.conf['do_mutual_check']:
             matches1, scores1 = find_nn(
-                sim.transpose(1, 2), self.conf['ratio_threshold'],
+                sim.transpose(1, 2), ratio_threshold,
                 self.conf['distance_threshold'])
             matches0 = mutual_check(matches0, matches1)
         return {

--- a/hloc/matchers/nearest_neighbor.py
+++ b/hloc/matchers/nearest_neighbor.py
@@ -38,7 +38,7 @@ class NearestNeighbor(BaseModel):
     def _forward(self, data):
         if data['descriptors0'].size(-1) == 0 or data['descriptors1'].size(-1) == 0:
             matches0 = torch.full(
-                [data['descriptors0'].size(0), data['descriptors0'].size(1)], -1,
+                data['descriptors0'].shape[:2], -1,
                 device=data['descriptors0'].device)
             return {
                 'matches0': matches0,

--- a/hloc/matchers/nearest_neighbor.py
+++ b/hloc/matchers/nearest_neighbor.py
@@ -37,11 +37,12 @@ class NearestNeighbor(BaseModel):
 
     def _forward(self, data):
         if data['descriptors0'].size(-1) == 0 or data['descriptors1'].size(-1) == 0:
-            b = data['descriptors0'].size(0)
-            device = data['descriptors0'].device
+            matches0 = torch.full(
+                [data['descriptors0'].size(0), data['descriptors0'].size(1)], -1,
+                device=data['descriptors0'].device)
             return {
-                'matches0': torch.zeros([b, 0]).to(device),
-                'matching_scores0': torch.zeros([b, 0]).to(device)
+                'matches0': matches0,
+                'matching_scores0': torch.zeros_like(matches0)
             }
         ratio_threshold = self.conf['ratio_threshold']
         if data['descriptors0'].size(-1) == 1 or data['descriptors1'].size(-1) == 1:


### PR DESCRIPTION
After #96, I was still running into issues with the NN matchers when both images had no detected features (which raises an error during `einsum`) so I moved the number of features check at the beginning of forward.

This should fix all issues (hopefully).