### PR TITLE
Fix Dockerfile for PyPI pycolmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 FROM colmap/colmap:latest
 MAINTAINER Paul-Edouard Sarlin
+ARG PYTHON_VERSION=3.8
 RUN apt-get update -y
-RUN apt-get install python3 python3-pip unzip wget -y
+RUN apt-get install -y unzip wget software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get -y update && \
+    apt-get install -y python${PYTHON_VERSION}
+RUN wget https://bootstrap.pypa.io/get-pip.py && python${PYTHON_VERSION} get-pip.py
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1
 COPY . /app
 WORKDIR app/
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
-RUN pip3 install jupyterlab notebook
+RUN pip3 install notebook


### PR DESCRIPTION
- PyPI pycolmap is built for Pyhton 3.7 and 3.8 only
- the COLMAP docker image is based in Ubuntu 18.04, which installs 3.6 by default
- this PR installs 3.8