### PR TITLE
Scalar detection uncertainty

### DIFF
--- a/hloc/extractors/sift.py
+++ b/hloc/extractors/sift.py
@@ -29,6 +29,7 @@ class SIFT(BaseModel):
         'max_keypoints': -1
     }
     required_inputs = ['image']
+    detection_noise = 1.0
 
     def _init(self, conf):
         self.root = conf['root']

--- a/hloc/extractors/superpoint.py
+++ b/hloc/extractors/superpoint.py
@@ -53,6 +53,7 @@ class SuperPoint(BaseModel):
         'fix_sampling': False,
     }
     required_inputs = ['image']
+    detection_noise = 2.0
 
     def _init(self, conf):
         if conf['fix_sampling']:


### PR DESCRIPTION
This PR adds an uncertainty associated to the detection of keypoints. It depends on the keypoint detector (lower for SIFT than SuperPoint) and on the image resolution of the extraction.
- This could be useful for downstream uses like PnP+RANSAC or SfM but is not implemented in hloc yet.
- For now this is a per-image scalar but this could be upgraded to a per-keypoint uncertainty (e.g. scale-dependent for SIFT) and to a full covariance matrix (e.g. Hessian of the detection heatmap).