### PR TITLE
Switched dir model dl from wget to gdown

### DIFF
--- a/hloc/extractors/dir.py
+++ b/hloc/extractors/dir.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-import subprocess
 import torch
 from zipfile import ZipFile
 import os

--- a/hloc/extractors/dir.py
+++ b/hloc/extractors/dir.py
@@ -5,6 +5,7 @@ import torch
 from zipfile import ZipFile
 import os
 import sklearn
+import gdown
 
 from ..utils.base_model import BaseModel
 
@@ -46,9 +47,7 @@ class DIR(BaseModel):
         if not checkpoint.exists():
             checkpoint.parent.mkdir(exist_ok=True)
             link = self.dir_models[conf['model_name']]
-            cmd = ['wget', '--no-check-certificate', '-r', link,
-                   '-O', str(checkpoint)+'.zip']
-            subprocess.run(cmd, check=True)
+            gdown.download(str(link), str(checkpoint)+'.zip', quiet=False)
             zf = ZipFile(str(checkpoint)+'.zip', 'r')
             zf.extractall(checkpoint.parent)
             zf.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scipy
 h5py
 pycolmap>=0.1.0
 kornia
+gdown


### PR DESCRIPTION
Hi,

I noticed that the checkpoint file download from Google Drive using wget isn't working anymore for DIR/Ap-GeM. I switched the download to use the gdown package, which seems to be working nicely.