### PR TITLE
Use the new pycolmap.Sift interface

### DIFF
--- a/hloc/__init__.py
+++ b/hloc/__init__.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     logger.warning('pycolmap is not installed, some features may not work.')
 else:
-    minimal_version = version.parse('0.1.0')
+    minimal_version = version.parse('0.2.0')
     found_version = version.parse(getattr(pycolmap, '__version__'))
     if found_version < minimal_version:
         logger.warning(

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ matplotlib
 plotly
 scipy
 h5py
-pycolmap>=0.1.0
+pycolmap>=0.2.0
 kornia
 gdown


### PR DESCRIPTION
https://github.com/colmap/pycolmap/pull/57 introduces a unified interface for CPU SIFT (vlfeat) and GPU SIFT. The later is 20x faster (30 images/s instead of 1.5) but seems slightly less accurate. Test with `pipeline_SfM` with `netvlad`, `sift`, `NN-ratio`:
```
previously
	num_points3D = 32407
	num_observations = 186116
	mean_track_length = 5.74308
	mean_observations_per_image = 1454.03
	mean_reprojection_error = 0.871393

new CPU
	num_points3D = 32388
	num_observations = 186084
	mean_track_length = 5.74546
	mean_observations_per_image = 1453.78
	mean_reprojection_error = 0.872367

new GPU
	num_points3D = 31489
	num_observations = 178612
	mean_track_length = 5.6722
	mean_observations_per_image = 1395.41
	mean_reprojection_error = 0.870559
```