### PR TITLE
Fix package discovery in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from setuptools import setup
+from setuptools import setup, find_packages
 
 description = ['Tools and baselines for visual localization and mapping']
 
@@ -14,7 +14,7 @@ with open(str(root / 'requirements.txt'), 'r') as f:
 setup(
     name='hloc',
     version=version,
-    packages=['hloc'],
+    packages=find_packages(),
     python_requires='>=3.6',
     install_requires=dependencies,
     author='Paul-Edouard Sarlin',


### PR DESCRIPTION
Added listing all packages for a complete installation using pip (see https://stackoverflow.com/questions/15368054/import-error-on-installed-package-using-setup-py/15368107#15368107 for more details)

Without this the package is unusable - `hloc.utils` and other packages were not being copied to site-packages. I suspect the example notebooks work because the directory is changed to the repo root.