### PR TITLE
Update SuperGlue to official master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,7 @@
 	url = https://github.com/mihaidusmanu/d2-net.git
 [submodule "third_party/SuperGluePretrainedNetwork"]
 	path = third_party/SuperGluePretrainedNetwork
-	url = https://github.com/skydes/SuperGluePretrainedNetwork.git
-	branch = fix-memory
+	url = https://github.com/magicleap/SuperGluePretrainedNetwork.git
 [submodule "third_party/deep-image-retrieval"]
 	path = third_party/deep-image-retrieval
 	url = https://github.com/naver/deep-image-retrieval.git


### PR DESCRIPTION
- The git submodule was still pointing to the patched fork
- Now pull the official repo instead
- This should fix accuracy issues when using SuperPoint with torch >= 1.10