### PR TITLE
Fix geometric verification for older feature files

### DIFF
--- a/hloc/triangulation.py
+++ b/hloc/triangulation.py
@@ -118,7 +118,7 @@ def geometric_verification(image_ids, reference, database_path, features_path,
         kps0, noise0 = get_keypoints(
             features_path, name0, return_uncertainty=True)
         noise0 = 1.0 if noise0 is None else noise0
-        kps0 = np.array([cam0.image_to_world(kp) for kp in kps0])
+        kps0 = np.stack(cam0.image_to_world(kps0))
 
         for name1 in pairs[name0]:
             id1 = image_ids[name1]
@@ -127,7 +127,7 @@ def geometric_verification(image_ids, reference, database_path, features_path,
             kps1, noise1 = get_keypoints(
                 features_path, name1, return_uncertainty=True)
             noise1 = 1.0 if noise1 is None else noise1
-            kps1 = np.array([cam1.image_to_world(kp) for kp in kps1])
+            kps1 = np.stack(cam1.image_to_world(kps1))
 
             matches = get_matches(matches_path, name0, name1)[0]
 

--- a/hloc/triangulation.py
+++ b/hloc/triangulation.py
@@ -117,6 +117,7 @@ def geometric_verification(image_ids, reference, database_path, features_path,
         cam0 = reference.cameras[image0.camera_id]
         kps0, noise0 = get_keypoints(
             features_path, name0, return_uncertainty=True)
+        noise0 = 1.0 if noise0 is None else noise0
         kps0 = np.array([cam0.image_to_world(kp) for kp in kps0])
 
         for name1 in pairs[name0]:
@@ -125,6 +126,7 @@ def geometric_verification(image_ids, reference, database_path, features_path,
             cam1 = reference.cameras[image1.camera_id]
             kps1, noise1 = get_keypoints(
                 features_path, name1, return_uncertainty=True)
+            noise1 = 1.0 if noise1 is None else noise1
             kps1 = np.array([cam1.image_to_world(kp) for kp in kps1])
 
             matches = get_matches(matches_path, name0, name1)[0]


### PR DESCRIPTION
https://github.com/cvg/Hierarchical-Localization/pull/178 breaks for feature files generated prior to https://github.com/cvg/Hierarchical-Localization/pull/158. For backward compatibility, we'll assume that the detection noise is 1.0px.