### PR TITLE
Added AdaLAM wrapper.

### DIFF
--- a/hloc/extract_features.py
+++ b/hloc/extract_features.py
@@ -250,6 +250,8 @@ def main(conf: Dict,
             size = np.array(data['image'].shape[-2:][::-1])
             scales = (original_size / size).astype(np.float32)
             pred['keypoints'] = (pred['keypoints'] + .5) * scales[None] - .5
+            if 'scales' in pred:
+                pred['scales'] *= scales.mean()
             # add keypoint uncertainties scaled to the original resolution
             uncertainty = getattr(model, 'detection_noise', 1) * scales.mean()
 

--- a/hloc/extractors/dog.py
+++ b/hloc/extractors/dog.py
@@ -69,6 +69,8 @@ class DoG(BaseModel):
                 device=getattr(pycolmap.Device, 'cuda' if use_gpu else 'cpu'))
 
         keypoints, scores, descriptors = self.sift.extract(image_np)
+        scales = keypoints[:, 2]
+        oris = np.rad2deg(keypoints[:, 3])
 
         if self.conf['descriptor'] in ['sift', 'rootsift']:
             # We still renormalize because COLMAP does not normalize well,
@@ -78,12 +80,12 @@ class DoG(BaseModel):
             descriptors = torch.from_numpy(descriptors)
         elif self.conf['descriptor'] == 'sosnet':
             center = keypoints[:, :2] + 0.5
-            scale = keypoints[:, 2] * self.conf['mr_size'] / 2
-            ori = -np.rad2deg(keypoints[:, 3])
+            laf_scale = scales * self.conf['mr_size'] / 2
+            laf_ori = -oris
             lafs = laf_from_center_scale_ori(
                 torch.from_numpy(center)[None],
-                torch.from_numpy(scale)[None, :, None, None],
-                torch.from_numpy(ori)[None, :, None]).to(image.device)
+                torch.from_numpy(laf_scale)[None, :, None, None],
+                torch.from_numpy(laf_ori)[None, :, None]).to(image.device)
             patches = extract_patches_from_pyramid(
                     image, lafs, PS=self.conf['patch_size'])[0]
             if len(keypoints) == 0:
@@ -94,6 +96,8 @@ class DoG(BaseModel):
             raise ValueError(f'Unknown descriptor: {self.conf["descriptor"]}')
 
         keypoints = torch.from_numpy(keypoints[:, :2])  # keep only x, y
+        scales = torch.from_numpy(scales)
+        oris = torch.from_numpy(oris)
         scores = torch.from_numpy(scores)
 
         if self.conf['max_keypoints'] != -1:
@@ -101,11 +105,15 @@ class DoG(BaseModel):
             # follow https://github.com/mihaidusmanu/pycolmap/issues/8
             indices = torch.topk(scores, self.conf['max_keypoints'])
             keypoints = keypoints[indices]
+            scales = scales[indices]
+            oris = oris[indices]
             scores = scores[indices]
             descriptors = descriptors[indices]
 
         return {
             'keypoints': keypoints[None],
+            'scales': scales[None],
+            'oris': oris[None],
             'scores': scores[None],
             'descriptors': descriptors.T[None],
         }

--- a/hloc/match_features.py
+++ b/hloc/match_features.py
@@ -58,6 +58,12 @@ confs = {
             'name': 'nearest_neighbor',
             'do_mutual_check': True,
         },
+    },
+    'adalam': {
+        'output': 'matches-adalam',
+        'model': {
+            'name': 'adalam'
+        },
     }
 }
 

--- a/hloc/matchers/adalam.py
+++ b/hloc/matchers/adalam.py
@@ -1,0 +1,50 @@
+import torch
+
+from ..utils.base_model import BaseModel
+
+from kornia.feature.adalam import AdalamFilter
+from kornia.utils.helpers import get_cuda_device_if_available
+
+
+class AdaLAM(BaseModel):
+    # See https://kornia.readthedocs.io/en/latest/_modules/kornia/feature/adalam/adalam.html.
+    default_conf = {
+        'area_ratio': 100,
+        'search_expansion': 4,
+        'ransac_iters': 128,
+        'min_inliers': 6,
+        'min_confidence': 200,
+        'orientation_difference_threshold': 30,
+        'scale_rate_threshold': 1.5,
+        'detected_scale_rate_threshold': 5,
+        'refit': True,
+        'force_seed_mnn': True,
+        'device': get_cuda_device_if_available()
+    }
+    required_inputs = [
+        'image0', 'image1',
+        'descriptors0', 'descriptors1',
+        'keypoints0', 'keypoints1',
+        'scales0', 'scales1',
+        'oris0', 'oris1']
+
+    def _init(self, conf):
+        self.adalam = AdalamFilter(conf)
+
+    def _forward(self, data):
+        assert data['keypoints0'].size(0) == 1
+        matches = self.adalam.match_and_filter(
+            data['keypoints0'][0], data['keypoints1'][0],
+            data['descriptors0'][0].T, data['descriptors1'][0].T,
+            data['image0'].shape[2 :], data['image1'].shape[2 :],
+            data['oris0'][0], data['oris1'][0],
+            data['scales0'][0], data['scales1'][0]
+        )
+        matches_new = torch.full(
+            (data['keypoints0'].size(1),), -1,
+            dtype=torch.int64, device=data['keypoints0'].device)
+        matches_new[matches[:, 0]] = matches[:, 1]
+        return {
+            'matches0': matches_new.unsqueeze(0),
+            'matching_scores0': torch.zeros(matches_new.size(0)).unsqueeze(0)
+        }

--- a/hloc/matchers/adalam.py
+++ b/hloc/matchers/adalam.py
@@ -41,7 +41,7 @@ class AdaLAM(BaseModel):
             matches = self.adalam.match_and_filter(
                 data['keypoints0'][0], data['keypoints1'][0],
                 data['descriptors0'][0].T, data['descriptors1'][0].T,
-                data['image0'].shape[2 :], data['image1'].shape[2 :],
+                data['image0'].shape[2:], data['image1'].shape[2:],
                 data['oris0'][0], data['oris1'][0],
                 data['scales0'][0], data['scales1'][0]
             )

--- a/hloc/matchers/adalam.py
+++ b/hloc/matchers/adalam.py
@@ -33,13 +33,18 @@ class AdaLAM(BaseModel):
 
     def _forward(self, data):
         assert data['keypoints0'].size(0) == 1
-        matches = self.adalam.match_and_filter(
-            data['keypoints0'][0], data['keypoints1'][0],
-            data['descriptors0'][0].T, data['descriptors1'][0].T,
-            data['image0'].shape[2 :], data['image1'].shape[2 :],
-            data['oris0'][0], data['oris1'][0],
-            data['scales0'][0], data['scales1'][0]
-        )
+        if data['keypoints0'].size(1) < 2 or data['keypoints1'].size(1) < 2:
+            matches = torch.zeros(
+                (0, 2), dtype=torch.int64,
+                device=data['keypoints0'].device)
+        else:
+            matches = self.adalam.match_and_filter(
+                data['keypoints0'][0], data['keypoints1'][0],
+                data['descriptors0'][0].T, data['descriptors1'][0].T,
+                data['image0'].shape[2 :], data['image1'].shape[2 :],
+                data['oris0'][0], data['oris1'][0],
+                data['scales0'][0], data['scales1'][0]
+            )
         matches_new = torch.full(
             (data['keypoints0'].size(1),), -1,
             dtype=torch.int64, device=data['keypoints0'].device)

--- a/hloc/triangulation.py
+++ b/hloc/triangulation.py
@@ -132,7 +132,10 @@ def geometric_verification(image_ids: Dict[str, int],
         kps0, noise0 = get_keypoints(
             features_path, name0, return_uncertainty=True)
         noise0 = 1.0 if noise0 is None else noise0
-        kps0 = np.stack(cam0.image_to_world(kps0))
+        if len(kps0) > 0:
+            kps0 = np.stack(cam0.image_to_world(kps0))
+        else:
+            kps0 = np.zeros((0, 2))
 
         for name1 in pairs[name0]:
             id1 = image_ids[name1]

--- a/hloc/triangulation.py
+++ b/hloc/triangulation.py
@@ -141,6 +141,7 @@ def geometric_verification(image_ids: Dict[str, int],
             kps1, noise1 = get_keypoints(
                 features_path, name1, return_uncertainty=True)
             noise1 = 1.0 if noise1 is None else noise1
+            print(name0, name1, kps1)
             kps1 = np.stack(cam1.image_to_world(kps1))
 
             matches = get_matches(matches_path, name0, name1)[0]

--- a/hloc/triangulation.py
+++ b/hloc/triangulation.py
@@ -141,8 +141,10 @@ def geometric_verification(image_ids: Dict[str, int],
             kps1, noise1 = get_keypoints(
                 features_path, name1, return_uncertainty=True)
             noise1 = 1.0 if noise1 is None else noise1
-            print(name0, name1, kps1)
-            kps1 = np.stack(cam1.image_to_world(kps1))
+            if len(kps1) > 0:
+                kps1 = np.stack(cam1.image_to_world(kps1))
+            else:
+                kps1 = np.zeros((0, 2))
 
             matches = get_matches(matches_path, name0, name1)[0]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ plotly
 scipy
 h5py
 pycolmap>=0.3.0
-kornia>=0.6.4
+kornia>=0.6.7
 gdown


### PR DESCRIPTION
## Some results on South-Building

SIFT + MNN
```
    num_reg_images = 128
    num_cameras = 1
    num_points3D = 40544
    num_observations = 215421
    mean_track_length = 5.31326
    mean_observations_per_image = 1682.98
    mean_reprojection_error = 0.930621
    num_input_images = 128
```

SIFT + AdaLAM
```
   num_reg_images = 128
   num_cameras = 1
   num_points3D = 38752
   num_observations = 214480
   mean_track_length = 5.53468
   mean_observations_per_image = 1675.62
   mean_reprojection_error = 0.949959
   num_input_images = 128
```

## Extra
- Bugfix in GV if image has no keypoints

## TODO
- Add  support for features without ori / scale (by setting `orientation_difference_threshold` and `scale_rate_threshold` to `None`)