### PR TITLE
Save checkpoints to the torch.hub cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ __pycache__
 *.egg-info
 .ipynb_checkpoints
 outputs/
-third_party/netvlad
 datasets/*
 !datasets/sacre_coeur/

--- a/hloc/extractors/dir.py
+++ b/hloc/extractors/dir.py
@@ -8,8 +8,8 @@ import gdown
 
 from ..utils.base_model import BaseModel
 
-dir_path = Path(__file__).parent / '../../third_party/deep-image-retrieval'
-sys.path.append(str(dir_path))
+sys.path.append(str(
+    Path(__file__).parent / '../../third_party/deep-image-retrieval'))
 os.environ['DB_ROOT'] = ''  # required by dirtorch
 
 from dirtorch.utils import common  # noqa: E402
@@ -25,7 +25,6 @@ sys.modules['sklearn.decomposition.pca'] = sklearn.decomposition._pca
 class DIR(BaseModel):
     default_conf = {
         'model_name': 'Resnet-101-AP-GeM',
-        'checkpoint_dir': dir_path / 'dirtorch/data',
         'whiten_name': 'Landmarks_clean',
         'whiten_params': {
             'whitenp': 0.25,
@@ -42,9 +41,10 @@ class DIR(BaseModel):
     }
 
     def _init(self, conf):
-        checkpoint = conf['checkpoint_dir'] / str(conf['model_name']+'.pt')
+        checkpoint = Path(
+            torch.hub.get_dir(), 'dirtorch', conf['model_name'] + '.pt')
         if not checkpoint.exists():
-            checkpoint.parent.mkdir(exist_ok=True)
+            checkpoint.parent.mkdir(exist_ok=True, parents=True)
             link = self.dir_models[conf['model_name']]
             gdown.download(str(link), str(checkpoint)+'.zip', quiet=False)
             zf = ZipFile(str(checkpoint)+'.zip', 'r')

--- a/hloc/extractors/netvlad.py
+++ b/hloc/extractors/netvlad.py
@@ -12,8 +12,6 @@ from ..utils.base_model import BaseModel
 
 logger = logging.getLogger(__name__)
 
-netvlad_path = Path(__file__).parent / '../../third_party/netvlad'
-
 EPS = 1e-6
 
 
@@ -45,7 +43,6 @@ class NetVLADLayer(nn.Module):
 class NetVLAD(BaseModel):
     default_conf = {
         'model_name': 'VGG16-NetVLAD-Pitts30K',
-        'checkpoint_dir': netvlad_path,
         'whiten': True
     }
     required_inputs = ['image']
@@ -61,9 +58,10 @@ class NetVLAD(BaseModel):
         assert conf['model_name'] in self.dir_models.keys()
 
         # Download the checkpoint.
-        checkpoint = conf['checkpoint_dir'] / str(conf['model_name'] + '.mat')
+        checkpoint = Path(
+            torch.hub.get_dir(), 'netvlad', conf['model_name'] + '.mat')
         if not checkpoint.exists():
-            checkpoint.parent.mkdir(exist_ok=True)
+            checkpoint.parent.mkdir(exist_ok=True, parents=True)
             link = self.dir_models[conf['model_name']]
             cmd = ['wget', link, '-O', str(checkpoint)]
             logger.info(f'Downloading the NetVLAD model with `{cmd}`.')


### PR DESCRIPTION
DIR and NetVLAD now save their checkpoints to the PyTorch cache dir given by `torch.hub.get_dir()`, which defaults to `~/.cache/torch/hub`: https://pytorch.org/docs/stable/hub.html#torch.hub.get_dir