### PR TITLE
Add CosPlace for global features extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ We show in [`pipeline_SfM.ipynb`](https://nbviewer.jupyter.org/github/cvg/Hierar
 
 - Supported local feature extractors: [SuperPoint](https://arxiv.org/abs/1712.07629), [D2-Net](https://arxiv.org/abs/1905.03561), [SIFT](https://www.cs.ubc.ca/~lowe/papers/ijcv04.pdf), and [R2D2](https://arxiv.org/abs/1906.06195).
 - Supported feature matchers: [SuperGlue](https://arxiv.org/abs/1911.11763) and nearest neighbor search with ratio test, distance test, and/or mutual check.
-- Supported image retrieval: [NetVLAD](https://arxiv.org/abs/1511.07247), [AP-GeM/DIR](https://github.com/naver/deep-image-retrieval), and [OpenIBL](https://github.com/yxgeee/OpenIBL).
+- Supported image retrieval: [NetVLAD](https://arxiv.org/abs/1511.07247), [AP-GeM/DIR](https://github.com/naver/deep-image-retrieval), [OpenIBL](https://github.com/yxgeee/OpenIBL) and [CosPlace](https://github.com/gmberton/CosPlace).
 
 Using NetVLAD for retrieval, we obtain the following best results:
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ We show in [`pipeline_SfM.ipynb`](https://nbviewer.jupyter.org/github/cvg/Hierar
 
 - Supported local feature extractors: [SuperPoint](https://arxiv.org/abs/1712.07629), [D2-Net](https://arxiv.org/abs/1905.03561), [SIFT](https://www.cs.ubc.ca/~lowe/papers/ijcv04.pdf), and [R2D2](https://arxiv.org/abs/1906.06195).
 - Supported feature matchers: [SuperGlue](https://arxiv.org/abs/1911.11763) and nearest neighbor search with ratio test, distance test, and/or mutual check.
-- Supported image retrieval: [NetVLAD](https://arxiv.org/abs/1511.07247), [AP-GeM/DIR](https://github.com/naver/deep-image-retrieval), [OpenIBL](https://github.com/yxgeee/OpenIBL) and [CosPlace](https://github.com/gmberton/CosPlace).
+- Supported image retrieval: [NetVLAD](https://arxiv.org/abs/1511.07247), [AP-GeM/DIR](https://github.com/naver/deep-image-retrieval), [OpenIBL](https://github.com/yxgeee/OpenIBL), and [CosPlace](https://github.com/gmberton/CosPlace).
 
 Using NetVLAD for retrieval, we obtain the following best results:
 

--- a/hloc/extract_features.py
+++ b/hloc/extract_features.py
@@ -133,6 +133,11 @@ confs = {
         'output': 'global-feats-openibl',
         'model': {'name': 'openibl'},
         'preprocessing': {'resize_max': 1024},
+    },
+    'cosplace': {
+        'output': 'global-feats-cosplace',
+        'model': {'name': 'cosplace'},
+        'preprocessing': {'resize_max': 1024},
     }
 }
 

--- a/hloc/extractors/cosplace.py
+++ b/hloc/extractors/cosplace.py
@@ -1,0 +1,46 @@
+'''
+Code for loading models trained with CosPlace as a global features extractor
+for geolocalization through image retrieval.
+Multiple models are available with different backbones. Below is a summary of
+models available (backbone : list of available output descriptors
+dimensionality). For example you can use a model based on a ResNet50 with
+descriptors dimensionality 1024.
+    ResNet18:  [32, 64, 128, 256, 512]
+    ResNet50:  [32, 64, 128, 256, 512, 1024, 2048]
+    ResNet101: [32, 64, 128, 256, 512, 1024, 2048]
+    ResNet152: [32, 64, 128, 256, 512, 1024, 2048]
+    VGG16:     [    64, 128, 256, 512]
+
+CosPlace paper: https://arxiv.org/abs/2204.02287
+'''
+
+import torch
+import torchvision.transforms as tvf
+
+from ..utils.base_model import BaseModel
+
+
+class CosPlace(BaseModel):
+    default_conf = {
+        'backbone': 'ResNet50',
+        'fc_output_dim' : 2048
+    }
+    required_inputs = ['image']
+    def _init(self, conf):
+        self.net = torch.hub.load(
+            'gmberton/CosPlace',
+            'get_trained_model',
+            backbone=conf['backbone'],
+            fc_output_dim=conf['fc_output_dim']
+        ).eval()
+        
+        mean = [0.485, 0.456, 0.406]
+        std = [0.229, 0.224, 0.225]
+        self.norm_rgb = tvf.Normalize(mean=mean, std=std)
+
+    def _forward(self, data):
+        image = self.norm_rgb(data['image'])
+        desc = self.net(image)
+        return {
+            'global_descriptor': desc,
+        }


### PR DESCRIPTION
I added CosPlace as a global features extractor as it is the latest SOTA in image retrieval for geolocalization.
There are multiple models available, I set as default the one with ResNet50 and features dimensionality of 2048, which provides a good trade-off between speed and accuracy.
However, I didn't provide any way to use the other models without changing the hardcoded default parameters in `default_conf` [here](https://github.com/gmberton/Hierarchical-Localization/blob/feature_add_cosplace/hloc/extractors/cosplace.py#L24). Perhaps I could add the option to select other models? I'm thinking that it might be useful to have lightweight features for large datasets (e.g. CosPlace with ResNet-101 with features dimensionality 128 which still outperforms 30x larger features from NetVLAD and OpenIBL).
[Link to CosPlace paper](https://arxiv.org/abs/2204.02287) - sorry for the self-promotion :wink: but the link should be useful to back the claims