### PR TITLE
Fix pycolmap version check

### DIFF
--- a/hloc/__init__.py
+++ b/hloc/__init__.py
@@ -21,9 +21,10 @@ except ImportError:
     logger.warning('pycolmap is not installed, some features may not work.')
 else:
     minimal_version = version.parse('0.3.0')
-    found_version = version.parse(getattr(pycolmap, '__version__'))
-    if found_version < minimal_version:
-        logger.warning(
-            'hloc now requires pycolmap>=%s but found pycolmap==%s, '
-            'please upgrade with `pip install --upgrade pycolmap`',
-            minimal_version, found_version)
+    found_version = pycolmap.__version__
+    if found_version != 'dev':
+        if version.parse(found_version) < minimal_version:
+            logger.warning(
+                'hloc now requires pycolmap>=%s but found pycolmap==%s, '
+                'please upgrade with `pip install --upgrade pycolmap`',
+                minimal_version, found_version)


### PR DESCRIPTION
It looks like some pycolmap conda packages have a dummy version `dev`. We'll skip the version check if so.