### PR TITLE
match_dense:assign_keypoints() Fix bug when no kpts detected

### DIFF
--- a/hloc/match_dense.py
+++ b/hloc/match_dense.py
@@ -100,6 +100,8 @@ def assign_keypoints(kpts: np.ndarray,
                      cell_size: Optional[int] = None):
     if not update:
         # Without update this is just a NN search
+	if len(other_cpts) == 0 or len(kpts) == 0:
+            return -np.ones(len(kpts))
         dist, kpt_ids = KDTree(np.array(other_cpts)).query(kpts)
         valid = (dist <= max_error)
         kpt_ids[~valid] = -1

--- a/hloc/match_dense.py
+++ b/hloc/match_dense.py
@@ -101,7 +101,7 @@ def assign_keypoints(kpts: np.ndarray,
     if not update:
         # Without update this is just a NN search
 	if len(other_cpts) == 0 or len(kpts) == 0:
-            return -np.ones(len(kpts))
+            return np.full(len(kpts), -1)
         dist, kpt_ids = KDTree(np.array(other_cpts)).query(kpts)
         valid = (dist <= max_error)
         kpt_ids[~valid] = -1


### PR DESCRIPTION
Empty kpts breaks KDTree