### PR TITLE
Pipeline for custom data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__
 .ipynb_checkpoints
 outputs/
 datasets/*
+query_processing_data/
 !datasets/sacre_coeur/

--- a/pipeline_custom.ipynb
+++ b/pipeline_custom.ipynb
@@ -1,0 +1,272 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1aa2d1ce-7d86-4375-a491-540b56a1df90",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pycolmap\n",
+    "\n",
+    "from hloc import extract_features, pairs_from_covisibility, match_features, triangulation, pairs_from_retrieval, localize_sfm, visualization\n",
+    "from hloc.utils import viz_3d, io\n",
+    "from hloc.localize_sfm import QueryLocalizer, pose_from_cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66d8ac9b-a21f-43df-bd2b-458fba523b5a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dataset_name = 'LabFront'\n",
+    "\n",
+    "dataset = Path(f'datasets/{dataset_name}/')\n",
+    "image_dir = dataset / 'images'\n",
+    "colmap_model_path = dataset / 'colmap/sparse/0'\n",
+    "\n",
+    "output_dir = dataset / 'hloc_data/'\n",
+    "# Local features and global descriptor filenames hardocded in feature confs\n",
+    "sfm_pairs_path = output_dir / 'sfm-pairs-covis20.txt' # Pairs used for SfM reconstruction\n",
+    "sfm_reconstruction_path = output_dir / 'sfm_reconstruction' # Path to reconstructed SfM\n",
+    "\n",
+    "# Query images\n",
+    "queries_img_dir = dataset / 'query'\n",
+    "\n",
+    "# Query data\n",
+    "query_processing_data_dir = Path(f'query_processing_data/{dataset_name}')\n",
+    "query_global_matches_path = query_processing_data_dir / 'global_match_pairs.txt'\n",
+    "query_local_match_path = query_processing_data_dir / 'local_match_data.h5'\n",
+    "query_results = query_processing_data_dir / 'query_results.txt'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aff8a17a-e45f-4a5a-9fc2-4d96e34edb57",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Feature extraction\n",
+    "## Extract local features in each data set image using Superpoint\n",
+    "local_feature_conf = extract_features.confs['superpoint_aachen']\n",
+    "local_features_path = extract_features.main(\n",
+    "    conf = local_feature_conf,\n",
+    "    image_dir = image_dir,\n",
+    "    export_dir = output_dir\n",
+    ")\n",
+    "\n",
+    "## Extract global descriptors from each image using NetVLad\n",
+    "global_descriptor_conf = extract_features.confs['netvlad']\n",
+    "global_descriptors_path = extract_features.main(\n",
+    "    conf = global_descriptor_conf,\n",
+    "    image_dir = image_dir,\n",
+    "    export_dir = output_dir\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0224548d-f5b9-448f-a997-5712f0207745",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Create SfM model using the local features just extracted\n",
+    "\n",
+    "## Note: There is already an SfM model created using Colmap available. However, that is created using the RootSIFT features.\n",
+    "## SfM model needs to be created using the new features.\n",
+    "\n",
+    "## Create matching pairs:\n",
+    "## Instead of creating image pairs by exhaustively searching through all possible pairs, we leverage the \n",
+    "## existing colmap model and form pairs by selecting the top 20 most covisibile neighbors for each image\n",
+    "pairs_from_covisibility.main(\n",
+    "    model = colmap_model_path,\n",
+    "    output = sfm_pairs_path,\n",
+    "    num_matched = 20\n",
+    ")\n",
+    "\n",
+    "## Use the created pairs to match images and store the matching result in a match file\n",
+    "match_features_conf = match_features.confs['superglue']\n",
+    "sfm_matches_path = match_features.main(\n",
+    "    conf = match_features_conf,\n",
+    "    pairs = sfm_pairs_path,\n",
+    "    features = local_feature_conf['output'], # This contains the file name where lcoal features are stored\n",
+    "    export_dir = output_dir\n",
+    ")\n",
+    "\n",
+    "## Use the matches to reconstruct an SfM model\n",
+    "reconstruction = triangulation.main(\n",
+    "    sfm_dir = sfm_reconstruction_path,\n",
+    "    reference_model = colmap_model_path,\n",
+    "    image_dir = image_dir,\n",
+    "    pairs = sfm_pairs_path,\n",
+    "    features = local_features_path,\n",
+    "    matches = sfm_matches_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "696ab530-9124-4fd5-939a-95fdc7a694be",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Visualize the reconstruction\n",
+    "\n",
+    "fig = viz_3d.init_figure()\n",
+    "viz_3d.plot_reconstruction(fig, reconstruction, color='rgba(255,0,0,0.5)', name=\"mapping\", points_rgb=True)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1123ae8-d2a7-4185-b689-082e2bc776dd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Localize a new Image\n",
+    "\n",
+    "query_image_name = 'query_2.png'\n",
+    "\n",
+    "# Extarct local features and global descriptor for the new image\n",
+    "query_local_features_path = extract_features.main(\n",
+    "    conf = local_feature_conf,\n",
+    "    image_dir = queries_img_dir,\n",
+    "    export_dir = query_processing_data_dir,\n",
+    "    image_list = [query_image_name]\n",
+    ")\n",
+    "\n",
+    "query_global_descriptor_path = extract_features.main(\n",
+    "    conf = global_descriptor_conf,\n",
+    "    image_dir = queries_img_dir,\n",
+    "    export_dir = query_processing_data_dir,\n",
+    "    image_list = [query_image_name]\n",
+    ")\n",
+    "\n",
+    "## Use global descriptor matching to get candidate matches\n",
+    "nearest_candidate_images = pairs_from_retrieval.save_global_candidates_for_query(\n",
+    "    db_descriptors = global_descriptors_path,\n",
+    "    query_descriptor = query_global_descriptor_path,\n",
+    "    query_image_names = [query_image_name],\n",
+    "    num_matched = 10,\n",
+    "    output_file_path = query_global_matches_path\n",
+    ")\n",
+    "\n",
+    "## Match the query image against the candidate pairs from above\n",
+    "match_features.match_from_paths(\n",
+    "    conf = match_features_conf,\n",
+    "    pairs_path = query_global_matches_path,\n",
+    "    match_path = query_local_match_path,\n",
+    "    feature_path_q = query_local_features_path,\n",
+    "    feature_path_ref = local_features_path\n",
+    ")\n",
+    "\n",
+    "## Now we have global candidate and thier mathces. We use this, along with SfM reconstruction to localize the image.\n",
+    "\n",
+    "camera = pycolmap.infer_camera_from_image(queries_img_dir / query_image_name)\n",
+    "ref_ids = [reconstruction.find_image_with_name(r).image_id for r in nearest_candidate_images]\n",
+    "conf = {\n",
+    "    'estimation': {'ransac': {'max_error': 12}},\n",
+    "    'refinement': {'refine_focal_length': True, 'refine_extra_params': True},\n",
+    "}\n",
+    "localizer = QueryLocalizer(reconstruction, conf)\n",
+    "ret, log = pose_from_cluster(\n",
+    "    localizer = localizer, \n",
+    "    qname = query_image_name, \n",
+    "    query_camera = camera, \n",
+    "    db_ids = ref_ids, \n",
+    "    features_path = local_features_path, \n",
+    "    matches_path = query_local_match_path,\n",
+    "    features_q_path = query_local_features_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca011477-2bf8-4d56-871d-0a53de76d952",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# visualization.visualize_loc_from_log(\n",
+    "#     image_dir = queries_img_dir, \n",
+    "#     query_name = query_image_name, \n",
+    "#     loc = log, \n",
+    "#     reconstruction = reconstruction, \n",
+    "#     db_image_dir = image_dir\n",
+    "# )\n",
+    "\n",
+    "fig = viz_3d.init_figure()\n",
+    "viz_3d.plot_reconstruction(fig, reconstruction, color='rgba(255,0,0,0.5)', points_rgb=True)\n",
+    "pose = pycolmap.Image(tvec=ret['tvec'], qvec=ret['qvec'])\n",
+    "viz_3d.plot_camera_colmap(fig, pose, camera, color='rgba(0,255,0,0.5)', name=query_image_name, fill=True)\n",
+    "# visualize 2D-3D correspodences\n",
+    "inl_3d = np.array([reconstruction.points3D[pid].xyz for pid in np.array(log['points3D_ids'])[ret['inliers']]])\n",
+    "viz_3d.plot_points(fig, inl_3d, color=\"lime\", ps=1, name=query_image_name)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b9ead3d-2098-4efa-b0e6-d388954e59bc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bead830-aedc-4893-b8fb-abc48841ab34",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I was looking to use hloc for following usecase which is not uncommon in vision-based localization:
- A 'map creator' creates a 'ground-truth map' of a place using a sequence of images.
- New users use this map to localize their own new images (without altering the data and features in the ground-truth map).

However, I think the examples provided don't directly address this usecase, as they are mostly written to evaluate hloc on datasets. As a result, the reference images and query images are tightly coupled. For example, in `pipeline_Aachen.ipynb`, the features for both the reference and query images are extracted together. Localizing query images wihtout updating the ground-truth data (eg. features db) requires changing the code. 
While the notebook `demo.ipynb` achieves something to this effect, it uses exhaustive matching which is impractical for most usecases.
I have added `pipeline_custom.ipynb` that demonstrates how to use hloc for one's own data (with some very small changes to the hloc APIs). 

If this is useful, I can add more documentation on how to generate one's own data (eg. generating colmap SfM model) if needed.