### PR TITLE
Update Dockerfile for recent colmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY . /app
 WORKDIR app/
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
-RUN pip3 install notebook
+RUN pip3 install --upgrade notebook ipywidgets


### PR DESCRIPTION
- Dropped Python 3.8
- Installed python3-pip

This allows the Dockerfile to build with the recent colmap releases.

Should fix:
- #320 
- #289 