### PR TITLE
Added EigenPlaces for retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ We show in [`pipeline_SfM.ipynb`](https://nbviewer.jupyter.org/github/cvg/Hierar
 
 - Supported local feature extractors: [SuperPoint](https://arxiv.org/abs/1712.07629), [DISK](https://arxiv.org/abs/2006.13566), [D2-Net](https://arxiv.org/abs/1905.03561), [SIFT](https://www.cs.ubc.ca/~lowe/papers/ijcv04.pdf), and [R2D2](https://arxiv.org/abs/1906.06195).
 - Supported feature matchers: [SuperGlue](https://arxiv.org/abs/1911.11763), its faster follow-up [LightGlue](https://github.com/cvg/LightGlue), and nearest neighbor search with ratio test, distance test, and/or mutual check. hloc also supports dense matching with [LoFTR](https://github.com/zju3dv/LoFTR).
-- Supported image retrieval: [NetVLAD](https://arxiv.org/abs/1511.07247), [AP-GeM/DIR](https://github.com/naver/deep-image-retrieval), [OpenIBL](https://github.com/yxgeee/OpenIBL), and [CosPlace](https://github.com/gmberton/CosPlace).
+- Supported image retrieval: [NetVLAD](https://arxiv.org/abs/1511.07247), [AP-GeM/DIR](https://github.com/naver/deep-image-retrieval), [OpenIBL](https://github.com/yxgeee/OpenIBL), [CosPlace](https://github.com/gmberton/CosPlace) and  [EigenPlaces](https://github.com/gmberton/EigenPlaces).
 
 Using NetVLAD for retrieval, we obtain the following best results:
 

--- a/hloc/extract_features.py
+++ b/hloc/extract_features.py
@@ -135,9 +135,9 @@ confs = {
         'model': {'name': 'openibl'},
         'preprocessing': {'resize_max': 1024},
     },
-    'cosplace': {
-        'output': 'global-feats-cosplace',
-        'model': {'name': 'cosplace'},
+    'eigenplaces': {
+        'output': 'global-feats-eigenplaces',
+        'model': {'name': 'eigenplaces'},
         'preprocessing': {'resize_max': 1024},
     }
 }

--- a/hloc/extractors/eigenplaces.py
+++ b/hloc/extractors/eigenplaces.py
@@ -1,17 +1,26 @@
 '''
-Code for loading models trained with CosPlace as a global features extractor
-for geolocalization through image retrieval.
+Code for loading models trained with EigenPlaces (or CosPlace) as a global
+features extractor for geolocalization through image retrieval.
 Multiple models are available with different backbones. Below is a summary of
 models available (backbone : list of available output descriptors
 dimensionality). For example you can use a model based on a ResNet50 with
 descriptors dimensionality 1024.
+
+EigenPlaces trained models:
+    ResNet18:  [     256, 512]
+    ResNet50:  [128, 256, 512, 2048]
+    ResNet101: [128, 256, 512, 2048]
+    VGG16:     [     512]
+
+CosPlace trained models:
     ResNet18:  [32, 64, 128, 256, 512]
     ResNet50:  [32, 64, 128, 256, 512, 1024, 2048]
     ResNet101: [32, 64, 128, 256, 512, 1024, 2048]
     ResNet152: [32, 64, 128, 256, 512, 1024, 2048]
     VGG16:     [    64, 128, 256, 512]
 
-CosPlace paper: https://arxiv.org/abs/2204.02287
+EigenPlaces paper (ICCV 2023): https://arxiv.org/abs/2308.10832
+CosPlace paper (CVPR 2022): https://arxiv.org/abs/2204.02287
 '''
 
 import torch
@@ -20,15 +29,16 @@ import torchvision.transforms as tvf
 from ..utils.base_model import BaseModel
 
 
-class CosPlace(BaseModel):
+class EigenPlaces(BaseModel):
     default_conf = {
-        'backbone': 'ResNet50',
+        'variant': 'EigenPlaces',
+        'backbone': 'ResNet101',
         'fc_output_dim' : 2048
     }
     required_inputs = ['image']
     def _init(self, conf):
         self.net = torch.hub.load(
-            'gmberton/CosPlace',
+            'gmberton/' + conf['variant'],
             'get_trained_model',
             backbone=conf['backbone'],
             fc_output_dim=conf['fc_output_dim']


### PR DESCRIPTION
Hi @sarlinpe !
Following [our conversation on the CosPlace PR](https://github.com/cvg/Hierarchical-Localization/pull/257), I have now changed the file `hloc/extractors/cosplace.py` with `hloc/extractors/eigenplaces.py` and added a `variant` config entry that can be switched between CosPlace and EigenPlaces (with the latter as default).

Here are the results on Aachen, although they don't really show much difference between NetVLAD and EigenPlaces, although I believe this might be due to Aachen being saturated (there were similar results with CosPlace).

| Method     | --num_loc      | Aachen Day   | Aachen Night |
| ------------- | ------------------ | ------------------ | -------------- |
| NetVLAD | 10 | 89.0 / 95.0 / 98.2 | 79.6 / 88.8 / 95.9 |
| EigenPlaces | 10 | 88.6 / 96.0 / 99.2 | 80.6 / 89.8 / 96.9 |
| NetVLAD | 50 | 90.5 / 96.4 / 99.3 | 84.7 / 92.9 / 100.0 |
| EigenPlaces | 50 | 90.2 / 96.2 / 99.6 | 83.7 / 90.8 / 96.9 |
