### PR TITLE
Fix call to pycolmap.verify_matches(...)

### DIFF
--- a/hloc/triangulation.py
+++ b/hloc/triangulation.py
@@ -115,8 +115,14 @@ def estimation_and_geometric_verification(
     logger.info("Performing geometric verification of the matches...")
     with OutputCapture(verbose):
         with pycolmap.ostream():
+            two_view_geometry_options = pycolmap.TwoViewGeometryOptions()
+            ransac_options = pycolmap.RANSACOptions()
+            ransac_options.max_num_trials = 20000
+            ransac_options.min_inlier_ratio = 0.1
+            two_view_geometry_options.ransac = ransac_options
+
             pycolmap.verify_matches(
-                database_path, pairs_path, max_num_trials=20000, min_inlier_ratio=0.1
+                database_path, pairs_path, two_view_geometry_options
             )
 
 


### PR DESCRIPTION
Function `verify_matches` expects type `pycolmap.TwoViewGeometryOptions` as its last argument.

While running the `pipeline_SfM.ipynb` notebook, I received an error during the first step of `3D reconstruction` when we call:

```
model = reconstruction.main(sfm_dir, images, sfm_pairs, feature_path, match_path)
```

It appears that within `reconstruction.main(...)` the call to `estimation_and_geometric_verification(...)` previously allowed the RANSAC options to be passed as kwargs, and that is no longer the case in `pycolmap` 0.4.0 and 0.5.0.  The resulting error is fixed by this commit.