### PR TITLE
extract_features.py argument fixes

### DIFF
--- a/hloc/extract_features.py
+++ b/hloc/extract_features.py
@@ -307,4 +307,11 @@ if __name__ == "__main__":
     parser.add_argument("--image_list", type=Path)
     parser.add_argument("--feature_path", type=Path)
     args = parser.parse_args()
-    main(confs[args.conf], args.image_dir, args.export_dir, args.as_half)
+    main(
+        confs[args.conf],
+        args.image_dir,
+        args.export_dir,
+        args.as_half,
+        args.image_list,
+        args.feature_path,
+    )


### PR DESCRIPTION
Fixes an issue where command line arguments `--image_list` and `--feature_path` were not being passed to the `main` function.