### PR TITLE
Exposed ALIKED feature extractor from LightGlue

### DIFF
--- a/hloc/extract_features.py
+++ b/hloc/extract_features.py
@@ -114,6 +114,34 @@ confs = {
             "resize_max": 1600,
         },
     },
+    "aliked-n16-rot": {
+        "output": "feats-aliked-n16-rot",
+        "model": {
+            "name": "aliked",
+            "model_name": "aliked-n16-rot",
+            "max_num_keypoints": -1,
+            "detection_threshold": 0.2,
+            "nms_radius": 2,
+        },
+        "preprocessing": {
+            "grayscale": False,
+            "resize_max": 1024,
+        },
+    },
+    "aliked-n32": {
+        "output": "feats-aliked-n32",
+        "model": {
+            "name": "aliked",
+            "model_name": "aliked-n32",
+            "max_num_keypoints": -1,
+            "detection_threshold": 0.2,
+            "nms_radius": 2,
+        },
+        "preprocessing": {
+            "grayscale": False,
+            "resize_max": 1024,
+        },
+    },
     # Global descriptors
     "dir": {
         "output": "global-feats-dir",

--- a/hloc/extract_features.py
+++ b/hloc/extract_features.py
@@ -114,28 +114,11 @@ confs = {
             "resize_max": 1600,
         },
     },
-    "aliked-n16-rot": {
-        "output": "feats-aliked-n16-rot",
+    "aliked-n16": {
+        "output": "feats-aliked-n16",
         "model": {
             "name": "aliked",
-            "model_name": "aliked-n16-rot",
-            "max_num_keypoints": -1,
-            "detection_threshold": 0.2,
-            "nms_radius": 2,
-        },
-        "preprocessing": {
-            "grayscale": False,
-            "resize_max": 1024,
-        },
-    },
-    "aliked-n32": {
-        "output": "feats-aliked-n32",
-        "model": {
-            "name": "aliked",
-            "model_name": "aliked-n32",
-            "max_num_keypoints": -1,
-            "detection_threshold": 0.2,
-            "nms_radius": 2,
+            "model_name": "aliked-n16",
         },
         "preprocessing": {
             "grayscale": False,

--- a/hloc/extractors/aliked.py
+++ b/hloc/extractors/aliked.py
@@ -17,7 +17,6 @@ class ALIKED(BaseModel):
         self.model = ALIKED_(**conf)
 
     def _forward(self, data):
-        image = data["image"]
         features = self.model(data)
 
         return {

--- a/hloc/extractors/aliked.py
+++ b/hloc/extractors/aliked.py
@@ -1,0 +1,27 @@
+from lightglue import ALIKED as ALIKED_
+
+from ..utils.base_model import BaseModel
+
+
+class ALIKED(BaseModel):
+    default_conf = {
+        "model_name": "aliked-n16",
+        "max_num_keypoints": -1,
+        "detection_threshold": 0.2,
+        "nms_radius": 2,
+    }
+    required_inputs = ["image"]
+
+    def _init(self, conf):
+        conf.pop("name")
+        self.model = ALIKED_(**conf)
+
+    def _forward(self, data):
+        image = data["image"]
+        features = self.model(data)
+
+        return {
+            "keypoints": [f for f in features["keypoints"]],
+            "keypoint_scores": [f for f in features["keypoint_scores"]],
+            "descriptors": [f.t() for f in features["descriptors"]],
+        }

--- a/hloc/match_features.py
+++ b/hloc/match_features.py
@@ -35,6 +35,13 @@ confs = {
             "features": "disk",
         },
     },
+    "aliked+lightglue": {
+        "output": "matches-aliked-lightglue",
+        "model": {
+            "name": "lightglue",
+            "features": "aliked",
+        },
+    },
     "superglue": {
         "output": "matches-superglue",
         "model": {


### PR DESCRIPTION
I exposed the ALIKED feature extractor from LightGlue. I added two versions: `feats-aliked-n16-rot` and `feats-aliked-n32`.

Should I expose all variants?

Matching is possible via LightGlue by using `aliked+lightglue`.

If you would like me to make some changes please let me know.