### PR TITLE
Change IncrementalMapperOptions to IncrementalPipelineOptions

### DIFF
--- a/hloc/reconstruction.py
+++ b/hloc/reconstruction.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
         nargs="+",
         default=[],
         help="List of key=value from {}".format(
-            pycolmap.IncrementalMapperOptions().todict()
+            pycolmap.IncrementalPipelineOptions().todict()
         ),
     )
     args = parser.parse_args().__dict__
@@ -188,7 +188,7 @@ if __name__ == "__main__":
         args.pop("image_options"), pycolmap.ImageReaderOptions()
     )
     mapper_options = parse_option_args(
-        args.pop("mapper_options"), pycolmap.IncrementalMapperOptions()
+        args.pop("mapper_options"), pycolmap.IncrementalPipelineOptions()
     )
 
     main(**args, image_options=image_options, mapper_options=mapper_options)


### PR DESCRIPTION
In the latest pycolmap IncrementalMapperOptions has been split in two and most options fall under IncrementalPipelineOptions.

Fixes: ```ValueError: Unknown option "multiple_models", allowed options and default values for IncrementalMapperOptions:```


In this PR I simply replaced the names but I'm open to suggestions for a more elegant solution.