### PR TITLE
NumPy 2 compat

### DIFF
--- a/hloc/utils/database.py
+++ b/hloc/utils/database.py
@@ -183,8 +183,8 @@ class COLMAPDatabase(sqlite3.Connection):
         self,
         name,
         camera_id,
-        prior_q=np.full(4, np.NaN),
-        prior_t=np.full(3, np.NaN),
+        prior_q=np.full(4, np.nan),
+        prior_t=np.full(3, np.nan),
         image_id=None,
     ):
         cursor = self.execute(


### PR DESCRIPTION
AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.. Did you mean: 'nan'?