### PR TITLE
provide gdown alternative for sattler 7scenes

### DIFF
--- a/hloc/pipelines/7Scenes/README.md
+++ b/hloc/pipelines/7Scenes/README.md
@@ -2,6 +2,7 @@
 
 ## Installation
 
+1.
 Download the images from the [7Scenes project page](https://www.microsoft.com/en-us/research/project/rgb-d-dataset-7-scenes/):
 ```bash
 export dataset=datasets/7scenes
@@ -9,8 +10,9 @@ for scene in chess fire heads office pumpkin redkitchen stairs; \
 do wget http://download.microsoft.com/download/2/8/5/28564B23-0828-408F-8631-23B1EFF1DAC8/$scene.zip -P $dataset \
 && unzip $dataset/$scene.zip -d $dataset && unzip $dataset/$scene/'*.zip' -d $dataset/$scene; done
 ```
-
+2.
 Download the SIFT SfM models and DenseVLAD image pairs, courtesy of Torsten Sattler:
+
 ```bash
 function download {
 wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate "https://docs.google.com/uc?export=download&id=$1" -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=$1" -O $2 && rm -rf /tmp/cookies.txt
@@ -19,7 +21,14 @@ unzip $2 -d $dataset && rm $2;
 download 1cu6KUR7WHO7G4EO49Qi3HEKU6n_yYDjb $dataset/7scenes_sfm_triangulated.zip
 download 1IbS2vLmxr1N0f3CEnd_wsYlgclwTyvB1 $dataset/7scenes_densevlad_retrieval_top_10.zip
 ```
+Alternatively, if you have ```gdown``` installed:
 
+```bash
+gdown 1cu6KUR7WHO7G4EO49Qi3HEKU6n_yYDjb $dataset/7scenes_sfm_triangulated.zip
+gdown 1IbS2vLmxr1N0f3CEnd_wsYlgclwTyvB1 $dataset/7scenes_densevlad_retrieval_top_10.zip
+```
+
+3.
 Download the rendered depth maps, courtesy of Eric Brachmann for [DSAC\*](https://github.com/vislearn/dsacstar):
 ```bash
 wget https://heidata.uni-heidelberg.de/api/access/datafile/4037 -O $dataset/7scenes_rendered_depth.tar.gz


### PR DESCRIPTION
For me the base script failed to get the triangulations. Probably due to large file size gdrive has some additional checks. Instead of dealing with that stuff just do it through gdown.