### PR TITLE
Fix score reversal issue when matches are reversed

### DIFF
--- a/hloc/utils/io.py
+++ b/hloc/utils/io.py
@@ -74,5 +74,6 @@ def get_matches(path: Path, name0: str, name1: str) -> Tuple[np.ndarray]:
     matches = np.stack([idx, matches[idx]], -1)
     if reverse:
         matches = np.flip(matches, -1)
+        scores = np.flip(scores)  # Fix score reversal issue when matches are reversed
     scores = scores[idx]
     return matches, scores


### PR DESCRIPTION
### Fix score reversal issue when matches are reversed

#### Issue
In the original implementation, when the matches are reversed (`reverse=True`), the `matches` array is flipped, but the corresponding `scores` array is not. This can cause the scores to mismatch with the reversed matches.

#### Solution
The proposed change adds a line to flip the `scores` array in the same way the `matches` array is flipped when `reverse=True`.

#### Code Change
```python
if reverse:
    matches = np.flip(matches, -1)
    scores = np.flip(scores)  # Flip scores to maintain correspondence with matches