### PR TITLE
Speed up query list generation for dense matching

### DIFF
--- a/hloc/match_dense.py
+++ b/hloc/match_dense.py
@@ -485,7 +485,10 @@ def match_and_assign(
     pairs = parse_retrieval(pairs_path)
     pairs = [(q, r) for q, rs in pairs.items() for r in rs]
     pairs = find_unique_new_pairs(pairs, None if overwrite else match_path)
-    required_queries = set(sum(pairs, ()))
+    required_queries = set()
+    for q, r in pairs:
+        required_queries.add(q)
+        required_queries.add(r)
 
     name2ref = {
         n: i for i, p in enumerate(feature_paths_refs) for n in list_h5_names(p)

--- a/hloc/match_dense.py
+++ b/hloc/match_dense.py
@@ -485,10 +485,7 @@ def match_and_assign(
     pairs = parse_retrieval(pairs_path)
     pairs = [(q, r) for q, rs in pairs.items() for r in rs]
     pairs = find_unique_new_pairs(pairs, None if overwrite else match_path)
-    required_queries = set()
-    for q, r in pairs:
-        required_queries.add(q)
-        required_queries.add(r)
+    required_queries = set(chain.from_iterable(pairs))
 
     name2ref = {
         n: i for i, p in enumerate(feature_paths_refs) for n in list_h5_names(p)


### PR DESCRIPTION
Python does not seem to be a fan of summing tuples > Python 3.9 was stuck on this line for several minutes on a large dataset before I killed it.

Probably related to https://stackoverflow.com/questions/41032630/why-is-pythons-built-in-sum-function-slow-when-used-to-flatten-a-list-of-lists

Switching to set(chain.from_iterable) made it ~instant.