### PR TITLE
Select reconstruction from folder outputs

### DIFF
--- a/hloc/reconstruction.py
+++ b/hloc/reconstruction.py
@@ -84,7 +84,7 @@ def run_reconstruction(
         return None
     logger.info(f"Reconstructed {len(reconstructions)} model(s).")
 
-    # Find the largest reconstruction by examining model folders #442
+    # Find the largest reconstruction by examining model folders #422
     largest_folder = None
     largest_num_images = 0
     for model_dir in models_path.iterdir():

--- a/hloc/reconstruction.py
+++ b/hloc/reconstruction.py
@@ -84,13 +84,12 @@ def run_reconstruction(
         return None
     logger.info(f"Reconstructed {len(reconstructions)} model(s).")
 
-    # Find the largest reconstruction by examining model folders
+    # Find the largest reconstruction by examining model folders #442
     largest_folder = None
     largest_num_images = 0
     for model_dir in models_path.iterdir():
         if not model_dir.is_dir():
             continue
-        # Load reconstruction from the binary files
         try:
             rec = pycolmap.Reconstruction(model_dir)
             num_images = rec.num_reg_images()
@@ -100,20 +99,15 @@ def run_reconstruction(
         except Exception as e:
             logger.warning(f"Could not load reconstruction from {model_dir}: {e}")
             continue
+    assert largest_folder is not None
 
-    if largest_folder is None:
-        logger.error("Could not find any valid reconstruction!")
-        return None
+    logger.info(f"Largest model is {largest_folder.name} with {largest_num_images} images.")
 
-    logger.info(f"Largest model is in {largest_folder.name} with {largest_num_images} images.")
-
-    # Move the files from the largest model
     for filename in ["images.bin", "cameras.bin", "points3D.bin"]:
         if (sfm_dir / filename).exists():
             (sfm_dir / filename).unlink()
         shutil.move(str(largest_folder / filename), str(sfm_dir))
     
-    # Return the reconstruction object for the largest model
     return pycolmap.Reconstruction(sfm_dir)
 
 

--- a/hloc/reconstruction.py
+++ b/hloc/reconstruction.py
@@ -84,23 +84,37 @@ def run_reconstruction(
         return None
     logger.info(f"Reconstructed {len(reconstructions)} model(s).")
 
-    largest_index = None
+    # Find the largest reconstruction by examining model folders
+    largest_folder = None
     largest_num_images = 0
-    for index, rec in reconstructions.items():
-        num_images = rec.num_reg_images()
-        if num_images > largest_num_images:
-            largest_index = index
-            largest_num_images = num_images
-    assert largest_index is not None
-    logger.info(
-        f"Largest model is #{largest_index} " f"with {largest_num_images} images."
-    )
+    for model_dir in models_path.iterdir():
+        if not model_dir.is_dir():
+            continue
+        # Load reconstruction from the binary files
+        try:
+            rec = pycolmap.Reconstruction(model_dir)
+            num_images = rec.num_reg_images()
+            if num_images > largest_num_images:
+                largest_folder = model_dir
+                largest_num_images = num_images
+        except Exception as e:
+            logger.warning(f"Could not load reconstruction from {model_dir}: {e}")
+            continue
 
+    if largest_folder is None:
+        logger.error("Could not find any valid reconstruction!")
+        return None
+
+    logger.info(f"Largest model is in {largest_folder.name} with {largest_num_images} images.")
+
+    # Move the files from the largest model
     for filename in ["images.bin", "cameras.bin", "points3D.bin"]:
         if (sfm_dir / filename).exists():
             (sfm_dir / filename).unlink()
-        shutil.move(str(models_path / str(largest_index) / filename), str(sfm_dir))
-    return reconstructions[largest_index]
+        shutil.move(str(largest_folder / filename), str(sfm_dir))
+    
+    # Return the reconstruction object for the largest model
+    return pycolmap.Reconstruction(sfm_dir)
 
 
 def main(


### PR DESCRIPTION
Fixes #422 

In theory we could also hardcode 0, given that COLMAP always saves the model with most registered images first, but this makes us agnostic of the COLMAP implementation. 