### PR TITLE
Allow custom estimation_options in localize_inloc.py

### DIFF
--- a/hloc/localize_inloc.py
+++ b/hloc/localize_inloc.py
@@ -64,7 +64,8 @@ def get_scan_pose(dataset_dir, rpath):
     return P_after_GICP
 
 
-def pose_from_cluster(dataset_dir, q, retrieved, feature_file, match_file, skip=None, estimation_options=None):
+def pose_from_cluster(dataset_dir, q, retrieved, feature_file, match_file, 
+                      skip=None, estimation_options=None):
     height, width = cv2.imread(str(dataset_dir / q)).shape[:2]
     cx = 0.5 * width
     cy = 0.5 * height
@@ -117,7 +118,8 @@ def pose_from_cluster(dataset_dir, q, retrieved, feature_file, match_file, skip=
     return ret, all_mkpq, all_mkpr, all_mkp3d, all_indices, num_matches
 
 
-def main(dataset_dir, retrieval, features, matches, results, skip_matches=None, estimation_options=None):
+def main(dataset_dir, retrieval, features, matches, results, 
+         skip_matches=None, estimation_options=None):
     assert retrieval.exists(), retrieval
     assert features.exists(), features
     assert matches.exists(), matches
@@ -144,7 +146,8 @@ def main(dataset_dir, retrieval, features, matches, results, skip_matches=None, 
     for q in tqdm(queries):
         db = retrieval_dict[q]
         ret, mkpq, mkpr, mkp3d, indices, num_matches = pose_from_cluster(
-            dataset_dir, q, db, feature_file, match_file, skip_matches, estimation_options
+            dataset_dir, q, db, feature_file, match_file, 
+            skip_matches, estimation_options
         )
 
         poses[q] = (

--- a/hloc/localize_inloc.py
+++ b/hloc/localize_inloc.py
@@ -64,7 +64,7 @@ def get_scan_pose(dataset_dir, rpath):
     return P_after_GICP
 
 
-def pose_from_cluster(dataset_dir, q, retrieved, feature_file, match_file, 
+def pose_from_cluster(dataset_dir, q, retrieved, feature_file, match_file,
                       skip=None, estimation_options=None):
     height, width = cv2.imread(str(dataset_dir / q)).shape[:2]
     cx = 0.5 * width
@@ -118,7 +118,7 @@ def pose_from_cluster(dataset_dir, q, retrieved, feature_file, match_file,
     return ret, all_mkpq, all_mkpr, all_mkp3d, all_indices, num_matches
 
 
-def main(dataset_dir, retrieval, features, matches, results, 
+def main(dataset_dir, retrieval, features, matches, results,
          skip_matches=None, estimation_options=None):
     assert retrieval.exists(), retrieval
     assert features.exists(), features
@@ -146,7 +146,7 @@ def main(dataset_dir, retrieval, features, matches, results,
     for q in tqdm(queries):
         db = retrieval_dict[q]
         ret, mkpq, mkpr, mkp3d, indices, num_matches = pose_from_cluster(
-            dataset_dir, q, db, feature_file, match_file, 
+            dataset_dir, q, db, feature_file, match_file,
             skip_matches, estimation_options
         )
 

--- a/hloc/localize_inloc.py
+++ b/hloc/localize_inloc.py
@@ -64,8 +64,15 @@ def get_scan_pose(dataset_dir, rpath):
     return P_after_GICP
 
 
-def pose_from_cluster(dataset_dir, q, retrieved, feature_file, match_file,
-                      skip=None, estimation_options=None):
+def pose_from_cluster(
+    dataset_dir,
+    q,
+    retrieved,
+    feature_file,
+    match_file,
+    skip=None,
+    estimation_options=None,
+):
     height, width = cv2.imread(str(dataset_dir / q)).shape[:2]
     cx = 0.5 * width
     cy = 0.5 * height
@@ -118,8 +125,15 @@ def pose_from_cluster(dataset_dir, q, retrieved, feature_file, match_file,
     return ret, all_mkpq, all_mkpr, all_mkp3d, all_indices, num_matches
 
 
-def main(dataset_dir, retrieval, features, matches, results,
-         skip_matches=None, estimation_options=None):
+def main(
+    dataset_dir,
+    retrieval,
+    features,
+    matches,
+    results,
+    skip_matches=None,
+    estimation_options=None,
+):
     assert retrieval.exists(), retrieval
     assert features.exists(), features
     assert matches.exists(), matches
@@ -146,8 +160,13 @@ def main(dataset_dir, retrieval, features, matches, results,
     for q in tqdm(queries):
         db = retrieval_dict[q]
         ret, mkpq, mkpr, mkp3d, indices, num_matches = pose_from_cluster(
-            dataset_dir, q, db, feature_file, match_file,
-            skip_matches, estimation_options
+            dataset_dir,
+            q,
+            db,
+            feature_file,
+            match_file,
+            skip_matches,
+            estimation_options,
         )
 
         poses[q] = (


### PR DESCRIPTION
Allows passing estimation_options to localize_inloc.py, while maintaining default behaviour if not provided.