### PR TITLE
Update Colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ With `hloc`, you can:
 
 ##
 
-## Quick start ➡️ [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1MrVs9b8aQYODtOGkoaGNF9Nji3sbCNMQ)
+## Quick start ➡️ [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1Eqoz-uLTCGeEWtH95FZyVs2vI-qkTOWr)
 
-Build 3D maps with Structure-from-Motion and localize any Internet image right from your browser! **You can now run `hloc` and COLMAP in Google Colab with GPU for free.** The notebook [`demo.ipynb`](https://colab.research.google.com/drive/1MrVs9b8aQYODtOGkoaGNF9Nji3sbCNMQ) shows how to run SfM and localization in just a few steps. Try it with your own data and let us know!
+Build 3D maps with Structure-from-Motion and localize any Internet image right from your browser! **You can now run `hloc` and COLMAP in Google Colab with GPU for free.** The notebook [`demo.ipynb`](https://colab.research.google.com/drive/1Eqoz-uLTCGeEWtH95FZyVs2vI-qkTOWr) shows how to run SfM and localization in just a few steps. Try it with your own data and let us know!
 
 ## Installation
 


### PR DESCRIPTION
Fixes a bug that was introduced in PR #467.

In the future, we should consider directly loading the demo notebook from the repo, e.g. using https://colab.research.google.com/github/cvg/Hierarchical-Localization/blob/master/demo.ipynb .

The problem is that the above version does not show the 3D viz by default (because we removed it in the local demo to save memory).