### PR TITLE
fix: reconstruction with pycolmap mapper option input level error

### DIFF
--- a/hloc/reconstruction.py
+++ b/hloc/reconstruction.py
@@ -78,11 +78,21 @@ def incremental_mapping(
         )
         pbars[-1].update(2)
 
+    pipeline_options = pycolmap.IncrementalPipelineOptions()
+    if options and isinstance(options, dict):
+        for k, v in options.items():
+            # Check if this parameter belongs to mapper
+            if hasattr(pipeline_options.mapper, k):
+                setattr(pipeline_options.mapper, k, v)
+            # Or belongs to top level (such as num_threads)
+            elif hasattr(pipeline_options, k):
+                setattr(pipeline_options, k, v)
+
     reconstructions = pycolmap.incremental_mapping(
         database_path,
         image_dir,
         sfm_path,
-        options=options or {},
+        options=pipeline_options,
         initial_image_pair_callback=restart_progress_bar,
         next_image_callback=lambda: pbars[-1].update(1),
     )


### PR DESCRIPTION
when exec reconstruction scripts with --mapper_option (example: filter_min_tri_angle=1.5) 
<img width="1906" height="1270" alt="image" src="https://github.com/user-attachments/assets/ee75ff8c-ec6f-46ed-93c7-09d22b63a810" />
because pycolmap.incremental_mapping function options' type is pycolmap._core.IncrementalPipelineOption. IncrementalPipelineOptions type includes top level (include mapper)and sub level (mapper's config parameter). The original code placed them on the same level(top level).  so an error occurred。
changed success 
<img width="1916" height="1074" alt="image" src="https://github.com/user-attachments/assets/9328c542-7749-4fa0-92fb-e2b2a83dac15" />
