### PR TITLE
Update Dockerfile for Python 3.10 and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM colmap/colmap:latest
-MAINTAINER Paul-Edouard Sarlin
-ARG PYTHON_VERSION=3.8
-RUN apt-get update -y
-RUN apt-get install -y unzip wget software-properties-common
+LABEL maintainer="Paul-Edouard Sarlin"
+ARG PYTHON_VERSION=3.10
+RUN apt-get update -y && \
+    apt-get install -y git unzip wget software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get -y update && \
     apt-get install -y python${PYTHON_VERSION}
 RUN wget https://bootstrap.pypa.io/get-pip.py && python${PYTHON_VERSION} get-pip.py
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1
 COPY . /app
-WORKDIR app/
+WORKDIR /app
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
 RUN pip3 install notebook


### PR DESCRIPTION
I tested the `Dockerfile` recently and it was not working with the current colmap image.

- Updated to Python 3.10 to avoid errors (This script does not work on Python 3.8. The minimum supported Python version is 3.10. Please use https://bootstrap.pypa.io/pip/3.8/get-pip.py instead.). Also for LoMa #495 it is needed.
- I have updated the MAINTAINER line because it is now deprecated and LABEL needs to be used.
- Combined `apt update` and `get` to save on layers.
- I added `git` to the dependencies since it was mising.
- Used an absolute path in the `WORKDIR` since it is good practice.