### PR TITLE
Pass explicit match path from match_features CLI

### DIFF
--- a/hloc/match_features.py
+++ b/hloc/match_features.py
@@ -162,7 +162,7 @@ def main(
     overwrite: bool = False,
 ) -> Path:
     if isinstance(features, Path) or Path(features).exists():
-        features_q = features
+        features_q = Path(features)
         if matches is None:
             raise ValueError(
                 "Either provide both features and matches as Path" " or both as names."
@@ -265,4 +265,10 @@ if __name__ == "__main__":
         "--conf", type=str, default="superglue", choices=list(confs.keys())
     )
     args = parser.parse_args()
-    main(confs[args.conf], args.pairs, args.features, args.export_dir)
+    main(
+        confs[args.conf],
+        args.pairs,
+        args.features,
+        export_dir=args.export_dir,
+        matches=args.matches,
+    )

--- a/tests/test_match_features_cli.py
+++ b/tests/test_match_features_cli.py
@@ -1,0 +1,51 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class MatchFeaturesCliTest(unittest.TestCase):
+    def test_cli_accepts_explicit_feature_and_match_paths(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            pairs = tmpdir / "pairs.txt"
+            features = tmpdir / "features.h5"
+            matches = tmpdir / "matches.h5"
+            pairs.write_text("", encoding="utf-8")
+            features.touch()
+
+            env = dict(os.environ)
+            env["PYTHONPATH"] = str(repo_root)
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "hloc.match_features",
+                    "--pairs",
+                    str(pairs),
+                    "--features",
+                    str(features),
+                    "--matches",
+                    str(matches),
+                    "--conf",
+                    "NN-mutual",
+                ],
+                cwd=repo_root,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+            self.assertEqual(
+                proc.returncode,
+                0,
+                "stdout:\n{0}\nstderr:\n{1}".format(proc.stdout, proc.stderr),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This fixes the `hloc.match_features` CLI path mode for callers that provide explicit feature and match HDF5 paths.

`match_features.main()` already supports this mode through its `matches` argument: when `features` is a real file path, `matches` must also be provided as a path. The CLI also defines `--matches`, but the module entrypoint did not pass `args.matches` into `main()`, so explicit-path CLI calls failed before matching started.

This PR:

- adds a unit test that reproduces the explicit `--features /path/features.h5 --matches /path/matches.h5` CLI path;
- passes `args.matches` from the CLI entrypoint into `main()`;
- converts an existing string feature path to `Path` before passing it to `match_from_paths()`.

## Validation

Run locally with an environment that has hloc's runtime dependencies installed:

```bash
python -m unittest tests.test_match_features_cli
python -m py_compile hloc/match_features.py tests/test_match_features_cli.py
```

Result:

```text
Ran 1 test in 0.786s
OK
```

I also checked that the existing name-based mode still returns the historical generated match filename pattern when pairs are empty and no model execution is needed.
